### PR TITLE
Improve preference menu

### DIFF
--- a/src/components/Preferences.jsx
+++ b/src/components/Preferences.jsx
@@ -3,63 +3,74 @@ import { PrefButton } from "../styledComponents/Button";
 import CategoryData from "../../CategoryData";
 import { SubTitle } from "../styledComponents/SubTitle";
 
-const QUESTION_COUNT = [5, 10, 15, 20];
+const QUESTION_COUNT_LIST = [5, 10, 15, 20];
 const DIFFICULTIES = ["easy", "medium", "hard"];
 
-export default function Preferences({ open, preferences, reset, update }) {
-  const handleChange = (event) => {
-    const { name, value } = event.target;
+const QUESTION_AMOUNT = "amount";
+const DIFFICULTY = "difficulty";
+const GAME_TYPE = "type";
+const CATEGORY = "category";
 
-    update(name, value);
+export default function Preferences({ open, preferences, reset, update }) {
+  const onSubmit = (event) => {
+    event.preventDefault();
+
+    const form = event.currentTarget;
+
+    update({
+      [QUESTION_AMOUNT]: new FormData(form).get(QUESTION_AMOUNT),
+      [DIFFICULTY]: new FormData(form).get(DIFFICULTY),
+      [GAME_TYPE]: new FormData(form).get(GAME_TYPE),
+      [CATEGORY]: new FormData(form).get(CATEGORY),
+    });
   };
 
   return (
-    <div className={`pref-container ${open ? "" : "close"}`}>
+    <form
+      onSubmit={onSubmit}
+      className={`pref-container ${open ? "" : "close"}`}
+    >
       <SubTitle>Number of Questions</SubTitle>
-      {QUESTION_COUNT.map((num) => (
+      {QUESTION_COUNT_LIST.map((num) => (
         <RadioButton
-          key={`key_${num}`}
-          id={`${num}ques`}
-          name="amount"
+          type="radio"
+          className="radio-button"
+          key={`${QUESTION_AMOUNT}_${num}`}
+          id={`${QUESTION_AMOUNT}_${num}`}
+          name={QUESTION_AMOUNT}
           value={num}
-          onChange={handleChange}
-          checked={preferences.amount === num}
+          defaultChecked={preferences.amount === num}
         >
           {num}
         </RadioButton>
       ))}
       <SubTitle>Difficulty</SubTitle>
-      {DIFFICULTIES.map((difficulty, index) => (
+      {DIFFICULTIES.map((difficulty) => (
         <RadioButton
-          key={index}
-          id={`${difficulty}ques`}
-          name="difficulty"
+          key={`${DIFFICULTY}_${difficulty}`}
+          id={`${DIFFICULTY}_${difficulty}`}
+          name={DIFFICULTY}
           value={difficulty}
           variant={difficulty}
-          onChange={handleChange}
-          checked={preferences.difficulty === difficulty}
+          defaultChecked={preferences.difficulty === difficulty}
         >
           <span style={{ textTransform: "capitalize" }}>{difficulty}</span>
         </RadioButton>
       ))}
       <SubTitle>Type</SubTitle>
       <RadioButton
-        key={1}
-        id="multi"
-        name="type"
+        id={`${GAME_TYPE}_multiple`}
+        name={GAME_TYPE}
         value="multiple"
-        onChange={handleChange}
-        checked={preferences.type === "multiple"}
+        defaultChecked={preferences.type === "multiple"}
       >
         Multiple
       </RadioButton>
       <RadioButton
-        key={2}
-        id="bool"
-        name="type"
+        id={`${GAME_TYPE}_boolean`}
+        name={GAME_TYPE}
         value="boolean"
-        onChange={handleChange}
-        checked={preferences.type === "boolean"}
+        defaultChecked={preferences.type === "boolean"}
       >
         Boolean
       </RadioButton>
@@ -67,26 +78,19 @@ export default function Preferences({ open, preferences, reset, update }) {
       {CategoryData.map((item) => (
         <RadioButton
           key={item.ID}
-          id={`category${item.CategoryID}`}
-          name="category"
+          id={`${CATEGORY}_${item.ID}`}
+          name={CATEGORY}
           value={item.CategoryID}
-          onChange={handleChange}
-          checked={preferences.category === item.CategoryID.toString()}
+          defaultChecked={preferences.category === item.CategoryID.toString()}
         >
           {item.CategoryName}
         </RadioButton>
       ))}
       <hr></hr>
       <div className="buttons">
-        {/* 
-          - Does this button really needed?.
-          - We save the changes on every value change.
-          - If you only want to save the changes on button click, you might consider using a From
-          and handle the submit event where you can gather the data from the form and save it into your reducer
-        */}
         <PrefButton>Save Prefs</PrefButton>
         <PrefButton onClick={reset}>Reset Prefs</PrefButton>
       </div>
-    </div>
+    </form>
   );
 }

--- a/src/components/RadioButton.jsx
+++ b/src/components/RadioButton.jsx
@@ -1,6 +1,6 @@
 import "./RadioButton.css";
 
-const RadioButton = ({ children, id, onChange, variant, checked, ...rest }) => {
+const RadioButton = ({ children, id, variant, ...rest }) => {
   return (
     <>
       <input
@@ -8,10 +8,7 @@ const RadioButton = ({ children, id, onChange, variant, checked, ...rest }) => {
         className={`radio-button ${variant ? variant : ""}`}
         id={id}
         {...rest}
-        onChange={onChange}
-        checked={checked}
       />
-
       <label htmlFor={id}>{children}</label>
     </>
   );

--- a/src/services-hooks/usePreferences.js
+++ b/src/services-hooks/usePreferences.js
@@ -12,7 +12,7 @@ const preferencesReducer = (state, action) => {
     case "update":
       return {
         ...state,
-        [action.name]: action.value,
+        ...action.payload,
       };
     case "reset":
       return action.payload || getInitialState();
@@ -28,8 +28,8 @@ const usePreferences = (initialState = getInitialState()) => {
     dispatch({ type: "reset", payload: initialState });
   }, [initialState]);
 
-  const update = useCallback((name, value) => {
-    dispatch({ type: "update", name, value });
+  const update = useCallback((newPreferences) => {
+    dispatch({ type: "update", payload: newPreferences });
   }, []);
 
   return useMemo(


### PR DESCRIPTION
This PR contains the following changes:

- `RadioButton` component got simplified
- `Update` method in `usePreferences` could update multiple states values if necessary
- `Preferences` component now use a `form` and an `onSubmit` instead of `onChange` to have a better UX.